### PR TITLE
Added Content Language Parameter to Enhancer Parameters for forcing processing language in the request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.apache.stanbol</groupId>
 	<artifactId>client</artifactId>
-	<version>1.1-jaxrs-1.1</version>
+	<version>1.2-jaxrs-1.1</version>
 	<packaging>jar</packaging>
 
 	<name>Apache Stanbol Client</name>
@@ -32,8 +32,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -64,20 +64,7 @@
 
 	<dependencies>
 		<!-- REST -->
-		
-<!-- 		<dependency> -->
-<!--             <groupId>org.jboss.resteasy</groupId> -->
-<!--             <artifactId>resteasy-client</artifactId> -->
-<!--             <version>3.0.8.Final</version> -->
-<!--             <exclusions> -->
-<!--                 <exclusion> -->
-<!--                     <groupId>org.slf4j</groupId> -->
-<!--                     <artifactId>slf4j-simple</artifactId> -->
-<!--                 </exclusion> -->
-<!--             </exclusions> -->
-<!--         </dependency> -->
-        
-        <dependency>
+		<dependency>
 			<groupId>com.sun.jersey</groupId>
 			<artifactId>jersey-client</artifactId>
 			<version>1.18.2</version>
@@ -149,14 +136,14 @@
             <artifactId>guava</artifactId>
             <version>14.0.1</version>
         </dependency>
-		
-		<!-- SolrJ -->
-		<dependency>
-               <artifactId>solr-solrj</artifactId>
-               <groupId>org.apache.solr</groupId>
-               <version>3.6.2</version>
+        
+        <!--  Commons IO -->
+        <dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
 		</dependency>
-
+		
 		<!-- JUnit -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/org/apache/stanbol/client/Enhancer.java
+++ b/src/main/java/org/apache/stanbol/client/Enhancer.java
@@ -33,6 +33,7 @@ public interface Enhancer
     public static final String STANBOL_ENHANCER_PATH = "enhancer";
     public static final String STANBOL_CHAIN_PATH = "chain";
     public static final String DEFAULT_CHAIN = "default";
+    public static final String CONTENT_LANGUAGE_HEADER = "Content-Language";
     
     
     /**

--- a/src/main/java/org/apache/stanbol/client/enhancer/impl/EnhancerImpl.java
+++ b/src/main/java/org/apache/stanbol/client/enhancer/impl/EnhancerImpl.java
@@ -16,6 +16,8 @@
  */
 package org.apache.stanbol.client.enhancer.impl;
 
+import java.util.Map;
+
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 
@@ -26,6 +28,7 @@ import org.apache.stanbol.client.services.exception.StanbolServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Maps;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.UniformInterfaceException;
@@ -69,11 +72,17 @@ public class EnhancerImpl implements Enhancer
     	
     	// TODO Include Dereferrencing stuff
     	
+    	// Content Language
+    	Map<String, String> headers = Maps.newHashMap();
+    	if(parameters.getContentLanguage() != null)
+    		headers.put(Enhancer.CONTENT_LANGUAGE_HEADER, parameters.getContentLanguage());
+    	
     	try{
     		EnhancementStructure response = RestClientExecutor.post(enhancerBuilder.build(),
     			parameters.getContent(), 
     			parameters.getOutputFormat(),
     			MediaType.TEXT_PLAIN_TYPE,
+    			headers,
     			EnhancementStructure.class);
     		
     		if (logger.isDebugEnabled())

--- a/src/main/java/org/apache/stanbol/client/enhancer/impl/EnhancerParameters.java
+++ b/src/main/java/org/apache/stanbol/client/enhancer/impl/EnhancerParameters.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Sets;
 /**
  * Collect all the parameters that can be sent to the enhancer in order to configure both the type of enrichment and the response
  * 
- * @author Rafa Haro <rharo@zaizi.com>
+ * @author Rafa Haro <rh@zaizi.com>
  *
  */
 public class EnhancerParameters {
@@ -69,6 +69,7 @@ public class EnhancerParameters {
     private String chain = Enhancer.DEFAULT_CHAIN;
     private Collection<String> dereferencedFields = Sets.newHashSet();
     private Optional<String> ldpath = Optional.absent();
+    private Optional<String> language = Optional.absent(); // Content Language
     
     public MediaType getOutputFormat(){
     	return outputFormat.value();
@@ -93,6 +94,10 @@ public class EnhancerParameters {
     	return ldpath.orNull();
     }
     
+    public String getContentLanguage(){
+    	return language.orNull();
+    }
+    
     public static class EnhancerParametersBuilder {
     	private final EnhancerParameters parameters = new EnhancerParameters();
     	
@@ -115,6 +120,11 @@ public class EnhancerParameters {
     	
     	public EnhancerParametersBuilder setChain(String chain){
     		this.parameters.chain = chain;
+    		return this;
+    	}
+    	
+    	public EnhancerParametersBuilder setContentLanguage(String language){
+    		this.parameters.language = Optional.of(language);
     		return this;
     	}
     	

--- a/src/main/java/org/apache/stanbol/client/entityhub/impl/EntityHubImpl.java
+++ b/src/main/java/org/apache/stanbol/client/entityhub/impl/EntityHubImpl.java
@@ -19,6 +19,7 @@ package org.apache.stanbol.client.entityhub.impl;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import javax.ws.rs.core.MediaType;
@@ -82,7 +83,9 @@ public class EntityHubImpl implements EntityHub
 		JSONArray array = null;
 		try{
 			array = RestClientExecutor.get(uri, 
-					new MediaType("application", "rdf+xml"), JSONArray.class);
+					new MediaType("application", "rdf+xml"),
+					Collections.<String, String> emptyMap(),
+					JSONArray.class);
 
 			if (logger.isDebugEnabled())
 			{
@@ -164,6 +167,7 @@ public class EntityHubImpl implements EntityHub
 		try{
 			InputStream response = RestClientExecutor.get(uri, 
 					new MediaType("application", "rdf+xml"),
+					Collections.<String, String> emptyMap(),
 					InputStream.class);
 			if (logger.isDebugEnabled())
 			{
@@ -216,6 +220,7 @@ public class EntityHubImpl implements EntityHub
 					is, 
 					MediaType.TEXT_XML_TYPE,
 					new MediaType("application", "rdf+xml"),
+					Collections.<String, String> emptyMap(),
 					String.class);
 			if (logger.isDebugEnabled())
 			{
@@ -278,6 +283,7 @@ public class EntityHubImpl implements EntityHub
 					is, 
 					new MediaType("application", "rdf+xml"),
 					new MediaType("application", "rdf+xml"),
+					Collections.<String, String> emptyMap(),
 					InputStream.class);
 
 			if (logger.isDebugEnabled())
@@ -385,6 +391,7 @@ public class EntityHubImpl implements EntityHub
 		try{
 			InputStream response = RestClientExecutor.get(uri, 
 					new MediaType("application", "rdf+xml"),
+					Collections.<String, String> emptyMap(),
 					InputStream.class);
 
 			if (logger.isDebugEnabled())
@@ -476,6 +483,7 @@ public class EntityHubImpl implements EntityHub
     	try{
     		response = RestClientExecutor.get(uri, 
     				new MediaType("application", "rdf+xml"),
+    				Collections.<String, String> emptyMap(),
     				InputStream.class);
     		if (logger.isDebugEnabled())
             {
@@ -548,6 +556,7 @@ public class EntityHubImpl implements EntityHub
     	try{		
     		response = RestClientExecutor.get(uri, 
     				new MediaType("application", "rdf+xml"),
+    				Collections.<String, String> emptyMap(),
     				InputStream.class);
     		
     	}catch(UniformInterfaceException e){

--- a/src/main/java/org/apache/stanbol/client/rest/RestClientExecutor.java
+++ b/src/main/java/org/apache/stanbol/client/rest/RestClientExecutor.java
@@ -17,6 +17,8 @@
 package org.apache.stanbol.client.rest;
 
 import java.net.URI;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.ws.rs.core.MediaType;
 
@@ -52,10 +54,16 @@ public class RestClientExecutor {
 		builder = Client.create(cc);
 	}
 
-	public static <T> T get(URI uri, MediaType acceptType,
+	public static <T> T get(URI uri,
+			MediaType acceptType,
+			Map<String, String> headers,
 			Class<T> returnType) {
 		WebResource target = builder.resource(uri);
 		Builder httpRequest = target.getRequestBuilder();
+		if(headers != null){
+			for(Entry<String, String> nextHeader:headers.entrySet())
+				httpRequest.header(nextHeader.getKey(), nextHeader.getValue());
+		}
 		if(acceptType != null)
 			httpRequest.accept(acceptType);
 		return httpRequest.get(returnType);
@@ -65,6 +73,7 @@ public class RestClientExecutor {
 			Object entity, 
 			MediaType acceptType,
 			MediaType contentType,
+			Map<String, String> headers,
 			Class<T> returnType) {
 		WebResource target = builder.resource(uri);
 		Builder httpRequest = target.getRequestBuilder();
@@ -72,6 +81,10 @@ public class RestClientExecutor {
 			httpRequest.accept(acceptType);
 		if(contentType != null)
 			httpRequest.type(contentType);
+		if(headers != null){
+			for(Entry<String, String> nextHeader:headers.entrySet())
+				httpRequest.header(nextHeader.getKey(), nextHeader.getValue());
+		}
 		httpRequest.entity(entity);
 		return httpRequest.post(returnType);
 	}

--- a/src/main/java/org/apache/stanbol/client/sparql/impl/SparqlImpl.java
+++ b/src/main/java/org/apache/stanbol/client/sparql/impl/SparqlImpl.java
@@ -17,6 +17,7 @@
 package org.apache.stanbol.client.sparql.impl;
 
 import java.net.URI;
+import java.util.Collections;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
@@ -75,7 +76,9 @@ public class SparqlImpl implements Sparql
         URI uri = sparqlBuilder.build();
         try{
         	String response = RestClientExecutor.get(uri,
-        			new MediaType("application", "sparql-results+xml"), String.class);
+        			new MediaType("application", "sparql-results+xml"),
+        			Collections.<String, String> emptyMap(),
+        			String.class);
         	
         	if (logger.isDebugEnabled())
             {

--- a/src/test/java/org/apache/stanbol/client/test/StanbolClientTest.java
+++ b/src/test/java/org/apache/stanbol/client/test/StanbolClientTest.java
@@ -23,10 +23,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.stanbol.client.Enhancer;
 import org.apache.stanbol.client.EntityHub;
 import org.apache.stanbol.client.StanbolClientFactory;
 import org.apache.stanbol.client.enhancer.impl.EnhancerParameters;
+import org.apache.stanbol.client.enhancer.impl.EnhancerParameters.EnhancerParametersBuilder;
 import org.apache.stanbol.client.enhancer.model.EnhancementStructure;
 import org.apache.stanbol.client.enhancer.model.EntityAnnotation;
 import org.apache.stanbol.client.enhancer.model.TextAnnotation;
@@ -314,11 +316,13 @@ public class StanbolClientTest
     public void testLanguage() throws Exception
     {
     	final Enhancer client = factory.createEnhancerClient();
-    	EnhancerParameters parameters = EnhancerParameters.
+    	String content = IOUtils.toString(
+    			this.getClass().getClassLoader().getResourceAsStream(TEST_ES_FILE));
+    	EnhancerParametersBuilder builder = EnhancerParameters.
     			builder().
     			setChain("language").
-    			setContent(this.getClass().getClassLoader().getResourceAsStream(TEST_ES_FILE)).
-    			build();
+    			setContent(content); 
+    	EnhancerParameters parameters = builder.build();
         EnhancementStructure enhancements = client.enhance(parameters);
 
         Assert.assertNotNull(enhancements);
@@ -332,5 +336,16 @@ public class StanbolClientTest
         Assert.assertFalse(enhancements.getLanguages().isEmpty());
         Assert.assertEquals(enhancements.getLanguages().size(), 1);
         Assert.assertEquals(enhancements.getLanguages().iterator().next(), "es");
+        
+        parameters = builder.setContentLanguage("en").build();
+        enhancements = client.enhance(parameters);
+
+        Assert.assertNotNull(enhancements);
+        Assert.assertTrue(enhancements.getEnhancements().size() == 2);
+        
+        Assert.assertFalse(enhancements.getLanguages().isEmpty());
+        Assert.assertEquals(enhancements.getLanguages().size(), 2);
+        Assert.assertTrue(enhancements.getLanguages().contains("en"));
+        Assert.assertTrue(enhancements.getLanguages().contains("es"));
     }
 }

--- a/src/test/java/org/apache/stanbol/client/test/StanbolClientTest.java
+++ b/src/test/java/org/apache/stanbol/client/test/StanbolClientTest.java
@@ -72,20 +72,6 @@ public class StanbolClientTest
 //    		"}" +
 //    		"ORDER BY DESC(?extraction_time) LIMIT 5";
     
-    public static void main(String[] args)
-    {
-        StanbolClientTest stanbolTest = new StanbolClientTest();
-        try
-        {
-           
-        }
-        catch (Exception e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-    }
-    
     @BeforeClass
     public static void startClient(){
     	factory = new StanbolClientFactory(STANBOL_ENDPOINT);

--- a/src/test/java/org/apache/stanbol/client/test/StanbolClientTest.java
+++ b/src/test/java/org/apache/stanbol/client/test/StanbolClientTest.java
@@ -193,8 +193,8 @@ public class StanbolClientTest
 //        System.out.println(prettyJsonString);
         JSONObject json = new JSONObject(jsonEnh);
         JSONArray array = json.getJSONArray("annotations");
-        Assert.assertEquals(array.getJSONObject(1).getString("start"), "24");
-        Assert.assertEquals(array.getJSONObject(1).getString("end"), "30");
+        Assert.assertEquals(array.getJSONObject(1).getString("start"), "0");
+        Assert.assertEquals(array.getJSONObject(1).getString("end"), "5");
         
     }
     


### PR DESCRIPTION
This PR enables user defined Content Language as Processing Language at the Enhancer service request. Sometimes, it is interesting to force the processing language for your chain. For example, if there aren't NLP models available for the target language, you can try using with other languages' models that might work fine.

It is also useful within Entity Linking process if you want to force a certain language for looking up for entities' labels without configuring it explicitily in the engine